### PR TITLE
Add debian as supported OS

### DIFF
--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -66,6 +66,25 @@ jobs:
               earthly +ros2-test-repos --distro=${{ matrix.distro }}
               earthly +ros2-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
               earthly +integration-check-switch --distro=${{ matrix.distro }}
+  infra-pkgs-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [debian:bookworm,debian:bullseye,debian:trixie]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build packages integration
+        run: | 
+              earthly +ros-apt-source --distro=${{ matrix.distro }}
+      - name: Test integration
+        run: | 
+              earthly +infra-test-repos --distro=${{ matrix.distro }}
+              earthly +infra-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
+              earthly +integration-check-switch --distro=${{ matrix.distro }}
   ros-ci:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble ]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye,debian:trixie]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal]
+        distro: [ubuntu:focal,debian:buster]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble ]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye,debian:trixie]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal]
+        distro: [ubuntu:focal, debian:buster]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye,debian:trixie]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian:bookworm,debian:bullseye,debian:trixie]
+        distro: [debian:bookworm,debian:bullseye]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye,debian:trixie]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/README
+++ b/README
@@ -5,10 +5,19 @@ This repository contains the packages for configuring keys and source for the RO
 The packages target the supported platforms for which binary packages are built. 
 The supported ROS-OS pairs are: 
 
-|       | Ubuntu Focal | Ubuntu Jammy | Ubuntu Noble | RHEL 8 | RHEL 9 |
-|-------|--------------|--------------|--------------|--------|--------|
-| ROS   | *            |              |              |        |        |
-| ROS 2 | *            | *            | *            | *      | *      |
+|                 | ROS | ROS 2 |
+|-----------------|-----|-------|
+| Debian Buster   | *   |       |
+| Ubuntu Focal    | *   | *     |
+| Ubuntu Jammy    |     | *     |
+| Ubuntu Noble    |     | *     |
+| RHEL 8          |     | *     |
+| RHEL 9          |     | *     |
+| Debian Bullseye |     | ^     |
+| Debian Bookworm |     | ^     |
+
+> [*] Testing with ROS debs
+> [^] Testing with Infra pkgs since no debs available.
 
 ## About the package
 

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.8
 
 # list of supported platforms per https://www.ros.org/reps/rep-2000.html.
 # This reflects supported platforms for humble, jazzy, kilted and rolling.
-ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal
+ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal debian:bookworm debian:buster debian:bullseye debian:trixie 
 
 dpkgbuild:
   ARG distro = debian:bookworm

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -88,6 +88,18 @@ ros2-test-repos:
   RUN apt update
   RUN apt install ros-rolling-ros-workspace -y
 
+infra-test-repos:
+  # Test that repo configuration is complete when installing keyring and apt-source packages. 
+  ARG distro = ubuntu:noble
+  ARG package = ros2-apt-source
+
+  FROM ${distro}
+  ENV DEBIAN_FRONTEND=noninteractive 
+  ENV TZ=Etc/UTC 
+  DO +INSTALL_PACKAGE --package=${package} --package_dir=./output/${distro}
+  RUN apt update
+  RUN apt install python3-colcon-core -y
+
 ros-test-repos:
   ARG distro = ubuntu:focal
   ARG package = ros-apt-source

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -66,14 +66,16 @@ test-aptsource-pkg-install:
           [ -s /usr/share/ros-apt-source/${repo}.sources \
   ]; then exit 0; else exit 1; fi;
   # test that embbeded key is passed
-  RUN if [[ ! legacy_distros[*] =~ ${distro} ]]; then \
-         cat /usr/share/ros-apt-source/${repo}.sources | grep 'BEGIN PGP PUBLIC KEY BLOCK'; \
+      RUN  if [ "$legacy_distros" == *"$distro"* ]; then \
+         if grep 'BEGIN PGP PUBLIC KEY BLOCK' /usr/share/ros-apt-source/${repo}.sources > /dev/null ; then \
+            exit 0; \
+            else exit 1; \
+            fi; \ 
         fi;
   RUN if  [ -f /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
           [ -e /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
           [ -s /usr/share/keyrings/${version}-archive-keyring.gpg \
   ]; then exit 0; else exit 1; fi; 
-
   RUN if  [ -h /etc/apt/sources.list.d/${version}.sources ]; then exit 0; else exit 1; fi;  
 
 ros2-test-repos:

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -3,6 +3,7 @@ VERSION 0.8
 # list of supported platforms per https://www.ros.org/reps/rep-2000.html.
 # This reflects supported platforms for humble, jazzy, kilted and rolling.
 ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal debian:bookworm debian:buster debian:bullseye debian:trixie 
+ARG --global legacy_distros = ubuntu:focal debian:buster debian:bullseye
 
 dpkgbuild:
   ARG distro = debian:bookworm
@@ -10,7 +11,12 @@ dpkgbuild:
   ENV DEBIAN_FRONTEND=noninteractive 
   ENV TZ=Etc/UTC 
   RUN apt-get update
-  RUN apt-get install -y debhelper>=13 lintian 
+  # Debian buster has an older version of debhelper but the backports archive has a compatible one
+  # Use backports version to avoid updating package logic for legacy versiob.
+  RUN if  [ ${distro} = "debian:buster" ]; then \ 
+      echo "deb http://archive.debian.org/debian-archive/debian buster-backports main" | tee /etc/apt/sources.list.d/backports.list > /dev/null && \ 
+      apt-get update && apt-get install -y  dwz/buster-backports debhelper/buster-backports>12 lintian/buster-backports \ 
+      ; else apt-get install -y debhelper lintian ; fi;  
 INSTALL_PACKAGE: 
   FUNCTION
   ARG --required package_dir
@@ -60,7 +66,7 @@ test-aptsource-pkg-install:
           [ -s /usr/share/ros-apt-source/${repo}.sources \
   ]; then exit 0; else exit 1; fi;
   # test that embbeded key is passed
-  RUN if [ ${distro} != "ubuntu:focal" ]; then \
+  RUN if [[ ! legacy_distros[*] =~ ${distro} ]]; then \
          cat /usr/share/ros-apt-source/${repo}.sources | grep 'BEGIN PGP PUBLIC KEY BLOCK'; \
         fi;
   RUN if  [ -f /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.8
 
 # list of supported platforms per https://www.ros.org/reps/rep-2000.html.
 # This reflects supported platforms for humble, jazzy, kilted and rolling.
-ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal debian:bookworm debian:buster debian:bullseye debian:trixie 
+ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal debian:bookworm debian:buster debian:bullseye
 ARG --global legacy_distros = ubuntu:focal debian:buster debian:bullseye
 
 dpkgbuild:

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -12,7 +12,7 @@ dpkgbuild:
   ENV TZ=Etc/UTC 
   RUN apt-get update
   # Debian buster has an older version of debhelper but the backports archive has a compatible one
-  # Use backports version to avoid updating package logic for legacy versiob.
+  # Use backports version to avoid updating package logic for legacy version.
   RUN if  [ ${distro} = "debian:buster" ]; then \ 
       echo "deb http://archive.debian.org/debian-archive/debian buster-backports main" | tee /etc/apt/sources.list.d/backports.list > /dev/null && \ 
       apt-get update && apt-get install -y  dwz/buster-backports debhelper/buster-backports>12 lintian/buster-backports \ 

--- a/ros-apt-source/debian/rules
+++ b/ros-apt-source/debian/rules
@@ -28,7 +28,7 @@ execute_after_dh_auto_build:
 		code_name=$$VERSION_CODENAME; \
 	 	short_version=$$(echo $$VERSION_ID | cut -c1-2); \
 		key=$$( echo "/usr/share/keyrings/ros2-archive-keyring.gpg"); \
-		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
+		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ) || ( [ "$$short_version" \> "11" ] && [ "$$ID" = "debian" ]); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
 		echo "Types: deb deb-src"; \
 	  echo "URIs: http://packages.ros.org/ros2/ubuntu"; \
 	  echo "Suites: $${code_name}"; \

--- a/ros-apt-source/debian/rules
+++ b/ros-apt-source/debian/rules
@@ -28,7 +28,7 @@ execute_after_dh_auto_build:
 		code_name=$$VERSION_CODENAME; \
 	 	short_version=$$(echo $$VERSION_ID | cut -c1-2); \
 		key=$$( echo "/usr/share/keyrings/ros2-archive-keyring.gpg"); \
-		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ) || ( [ "$$short_version" \> "11" ] && [ "$$ID" = "debian" ]); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
+		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ) || ( [ "$$short_version" \> "11" ] && [ "$$ID" = "debian" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
 		echo "Types: deb deb-src"; \
 	  echo "URIs: http://packages.ros.org/ros2/ubuntu"; \
 	  echo "Suites: $${code_name}"; \


### PR DESCRIPTION
### Description

This PR adds support for the necessary Debian versions. Debian trixie could not be added due to some conflict with the key. See [README](https://github.com/ros-infrastructure/ros-apt-source/blob/954bf20bb13d952ee10aa628046ea560681440b8/README) for details on supported ROS-OS pairs. 
For testing of the Debian distributions without ROS debs deployed the infrastructure packages are used to exercise that the workflow works.