### PR TITLE
 Fix  SHA generation

### DIFF
--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -39,7 +39,7 @@ BUILD_PACKAGE:
   # Issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033894
   RUN if  [ ${distro} != "debian:bookworm" ]; then \ 
       lintian ; fi;  
-  RUN for f in ../*.deb; do sha256sum $f >> $f.sha256.txt; done 
+  RUN cd .. && for f in *.deb; do sha256sum $f >> $f.sha256.txt; done 
   SAVE ARTIFACT ../*.txt AS LOCAL output/${target}/
   SAVE ARTIFACT ../*.dsc AS LOCAL output/${target}/
   SAVE ARTIFACT ../*.tar.xz AS LOCAL output/${target}/

--- a/ros2-release/Earthfile
+++ b/ros2-release/Earthfile
@@ -12,7 +12,7 @@ BUILD_PACKAGE:
   COPY . /tmp/$package
   RUN rpmbuild -ba ${package}.spec --define "_topdir /tmp/$package/rpm" --define "_sourcedir /tmp/$package"
   RUN rpmlint /tmp/$package/rpm/RPMS/noarch/${package}*.rpm /tmp/$package/rpm/SRPMS/${package}*.src.rpm
-  RUN for f in  /tmp/$package/rpm/RPMS/noarch/${package}*.rpm; do sha256sum $f >> $f.sha256.txt; done 
+  RUN cd /tmp/$package/rpm/RPMS/noarch/ && for f in  ${package}*.rpm; do sha256sum $f >> $f.sha256.txt; done 
   SAVE ARTIFACT /tmp/$package/rpm/RPMS/noarch/${package}*.rpm AS LOCAL output/
   SAVE ARTIFACT /tmp/$package/rpm/RPMS/noarch/${package}*.txt AS LOCAL output/
   SAVE ARTIFACT /tmp/$package/rpm/SRPMS/${package}*.src.rpm AS LOCAL output/


### PR DESCRIPTION
### Description
Use correct folder when generating the SHA256. This should have gone with #20 but got lost on my git tree. 
